### PR TITLE
[CD] [69842562] Optionally support Confusion

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :development, :test do
   gem 'rails-api'
   gem 'rspec'
   gem 'rack-test'
+  gem 'pry'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,7 @@ GEM
     arel (4.0.0)
     atomic (1.1.10)
     builder (3.1.4)
+    coderay (1.1.0)
     diff-lcs (1.2.4)
     erubis (2.7.0)
     hike (1.2.3)
@@ -42,10 +43,15 @@ GEM
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
+    method_source (0.8.2)
     mime-types (1.23)
     minitest (4.7.5)
     multi_json (1.7.7)
     polyglot (0.3.3)
+    pry (0.9.12.6)
+      coderay (~> 1.0)
+      method_source (~> 0.8)
+      slop (~> 3.4)
     rack (1.5.2)
     rack-protection (1.5.1)
       rack
@@ -87,6 +93,7 @@ GEM
       tilt (~> 1.3, >= 1.3.4)
     sinatra-respond_to (0.9.0)
       sinatra (~> 1.3)
+    slop (3.5.0)
     sprockets (2.10.0)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -110,6 +117,7 @@ PLATFORMS
 
 DEPENDENCIES
   ops!
+  pry
   rack-test
   rails
   rails-api

--- a/README.md
+++ b/README.md
@@ -5,7 +5,14 @@ Ops
 
 This gem provides standardized support for obtaining environment, version, and heartbeat information from Sinatra or Rails-based web applications.
 
-**You will likely want to block or restrict access to the `/ops/env` route since this exposes all of your currently set environment variables (e.g. any API keys set as env vars) to the public.**
+It optionally provides support for obtaining configuration data from a service named Confusion.
+
+**You will likely want to block or restrict access to the following routes:**
+
+Route            | Notes
+---------------- | -----
+`/ops/env`       | Exposes all of your environment variables (e.g. any API keys set as environment variables) to the public
+`/ops/confusion` | Exposes all of your `confusion` keys and values to the public (if you're using `confusion`)
 
 Typical usage:
 
@@ -14,6 +21,7 @@ Typical usage:
 /ops/version.json - displays version info as JSON
 /ops/heartbeat    - returns 'OK' if the app is alive
 /ops/env          - display the currently set environment variables
+/ops/confusion    - returns configuration data from Confusion as JSON (optional)
 ```
 
 This gem replaces the now-deprecated [ops_routes](https://github.com/primedia/ops_routes).
@@ -26,6 +34,7 @@ Installation
 1. Add the gem to your project's Gemfile:
     ```ruby
     gem 'ops'
+    gem 'configuration_client', '~> 0.7.0' # optional
     ```
 
 2. Add the following to application.rb:
@@ -34,6 +43,7 @@ Installation
     Ops.setup do |config|
       config.file_root = Rails.root
       config.environment = Rails.env
+      config.use_confusion = true # optional
     end
     ```
 
@@ -49,6 +59,7 @@ Installation
 
     ```ruby
     gem 'ops'
+    gem 'configuration_client', '~> 0.7.0' # optional
     ```
 
 2. Add the following to config.ru:
@@ -61,6 +72,7 @@ Installation
     Ops.setup do |config|
       config.file_root = File.dirname __FILE__
       config.environment = ENV['RACK_ENV']
+      config.use_confusion = true # optional
     end
 
     run Rack::URLMap.new \
@@ -85,7 +97,7 @@ Additionally, you can specify custom heartbeat monitoring pages as follows:
 ```ruby
 Ops.add_heartbeat :mysql do
   conn = ActiveRecord::Base.connection
-  migrations = conn.select_all("SELECT COUNT(1) FROM schema_migrations;") 
+  migrations = conn.select_all("SELECT COUNT(1) FROM schema_migrations;")
   conn.disconnect!
 end
 ```

--- a/lib/ops.rb
+++ b/lib/ops.rb
@@ -4,16 +4,33 @@ require 'ops/revision'
 require 'ops/heartbeat'
 require 'ops/server'
 
+begin
+  require 'configuration_client'
+rescue LoadError
+  # Confusion configuration service is unavailable
+end
+
 module Ops
   class << self
-    def new
-      Server.new
+    def new(path = '/')
+      Rack::Builder.new {
+        map(path) { run Server.new }
+        if Ops.use_confusion?
+          map(Ops.confusion_path(path)) { run ConfigurationClient::Middleware.new }
+        end
+      }.to_app
     end
 
     def rack_app(path)
-      Rack::Builder.new {
-        map(path) { run Ops.new }
-      }.to_app
+      Ops.new(path)
+    end
+
+    def use_confusion?
+      Ops.config.use_confusion && defined?(::ConfigurationClient)
+    end
+
+    def confusion_path(prefix)
+      File.join(prefix, 'confusion')
     end
   end
 end


### PR DESCRIPTION
Provide a configuration for enabling Confusion support; it is disabled
by default.

If Confusion support is enabled and the configuration_client gem is
loaded, provide a /confusion route. This route will make an inquiry
about the host application's features/settings and return a JSON
response.
