### PR TITLE
[LF] [000000] Allow configurable repo name

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ops (0.5.2)
+    ops (0.6.0)
       sinatra (>= 1.2.0)
       sinatra-respond_to (>= 0.7.0)
 
@@ -87,10 +87,10 @@ GEM
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)
     simplecov-html (0.7.1)
-    sinatra (1.4.5)
-      rack (~> 1.4)
+    sinatra (1.4.7)
+      rack (~> 1.5)
       rack-protection (~> 1.4)
-      tilt (~> 1.3, >= 1.3.4)
+      tilt (>= 1.3, < 3)
     sinatra-respond_to (0.9.0)
       sinatra (~> 1.3)
     slop (3.5.0)
@@ -124,3 +124,6 @@ DEPENDENCIES
   rake
   rspec
   simplecov
+
+BUNDLED WITH
+   1.11.2

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Installation
     Ops.setup do |config|
       config.file_root = Rails.root
       config.environment = Rails.env
+      config.repo_name = 'my_repository_name'
       config.config_service_adapter = something_that_responds_to_call # optional
     end
     ```

--- a/lib/ops/server/helpers.rb
+++ b/lib/ops/server/helpers.rb
@@ -25,8 +25,12 @@ module Ops
       github_link 'commit', commit
     end
 
+    def repo_name
+      Ops.config[:repo_name] || app_name
+    end
+
     def github_link(resource, subresource)
-      "<a href='#{GITHUB_ORG_LINK}/#{app_name}/#{resource}/#{subresource}'>#{subresource}</a>" unless subresource =~ /^Unknown/
+      "<a href='#{GITHUB_ORG_LINK}/#{repo_name}/#{resource}/#{subresource}'>#{subresource}</a>" unless subresource =~ /^Unknown/
     end
 
     def print_detail(object, indent = 0)

--- a/lib/ops/version.rb
+++ b/lib/ops/version.rb
@@ -1,3 +1,3 @@
 module Ops
-  VERSION = '0.5.2'
+  VERSION = '0.6.0'
 end


### PR DESCRIPTION
allow configurable repository name so links for `Last Commit` do not always break

- see http://emailsvc-01.qa.atl.primedia.com/ops/version as a broken example, where the github URI is based on the apps root directory name rather than the name of a valid repository
- this will also fix `Previous Versions` links

`be rake spec` passes but `be rake test:examples` was failing in this branch and dev for reasons i havent explored